### PR TITLE
Bump d3-color from 2.0.0 to 3.1.0 with package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1445,9 +1445,9 @@
             "dev": true
         },
         "d3-color": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-            "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
         },
         "d3-dispatch": {
             "version": "2.0.0",
@@ -1474,6 +1474,13 @@
             "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
             "requires": {
                 "d3-color": "1 - 2"
+            },
+            "dependencies": {
+                "d3-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+                    "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+                }
             }
         },
         "d3-path": {
@@ -1509,6 +1516,13 @@
                 "d3-ease": "1 - 2",
                 "d3-interpolate": "1 - 2",
                 "d3-timer": "1 - 2"
+            },
+            "dependencies": {
+                "d3-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+                    "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+                }
             }
         },
         "d3-zoom": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     },
     "homepage": "https://github.com/algrx/algorithmx",
     "dependencies": {
-        "d3-color": "^2.0.0",
+        "d3-color": "^3.1.0",
         "d3-dispatch": "^2.0.0",
         "d3-drag": "^2.0.0",
         "d3-ease": "^2.0.0",


### PR DESCRIPTION
Using ```npm i d3-color``` updated the structure of package-lock.json as well. I discovered that this was because I was using a recent version of npm and node.js. To remedy this, I rolled my npm and node to versions compatible with the structure you have for package-lock.json, i.e. (npm 6.7.0 and node 11.15.0). This resulted in far smaller update changes in package-lock.json. 

I want to note that, although I have updated d3-color, d3-interpolate and d3-transition still wants to use d3-color 2.0.0. You will see in the change log that it is bound to versions "1-2". 

On a side note, the fix I have currently implemented in my own project to overcome the current d3-color vulnerability is adding this override (I included dependencies for context);
```
  "dependencies": {
    "@babel/plugin-proposal-class-properties": "^7.18.6",
    "algorithmx": "^2.0.2",
    "jsnetworkx": "github:Joshnovski/jsnetworkx#update-lodash",
    "react": "^18.2.0",
    "react-dom": "^18.2.0",
    "react-router-dom": "^6.22.0",
    "seedrandom": "^3.0.5"
  },
  "overrides": {
    "d3-color": "3.1.0"
  }
```
At the bottom of my package.json file. With this override + running ```npm i``` I am not getting vulnerability flags on my end.